### PR TITLE
Preserve query items without a value

### DIFF
--- a/DeepLinkKit.xcodeproj/project.pbxproj
+++ b/DeepLinkKit.xcodeproj/project.pbxproj
@@ -993,6 +993,20 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Tests/Pods-Tests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		DE56F9AB1BD6B0140090BF8C /* Specta Focus Check */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Specta Focus Check";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Tests/BuildScripts/specta-focus-check.sh\"";
+		};
 		F7AECAC5E12B21557769080B /* Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1007,20 +1021,6 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ReceiverDemoSwift/Pods-ReceiverDemoSwift-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
-		};
-		DE56F9AB1BD6B0140090BF8C /* Specta Focus Check */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Specta Focus Check";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Tests/BuildScripts/specta-focus-check.sh\"";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -1169,6 +1169,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				STRIP_INSTALLED_PRODUCT = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1403,6 +1404,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				STRIP_INSTALLED_PRODUCT = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Test;

--- a/DeepLinkKit/Categories/NSString+DPLQuery.m
+++ b/DeepLinkKit/Categories/NSString+DPLQuery.m
@@ -8,7 +8,7 @@
         NSString *value = [parameters[key] description];
         key   = [key DPL_stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
         value = [value DPL_stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-        [query appendFormat:@"%@%@=%@", (idx > 0) ? @"&" : @"", key, value];
+        [query appendFormat:@"%@%@%@%@", (idx > 0) ? @"&" : @"", key, (value.length > 0) ? @"=" : @"", value];
     }];
     return [query copy];
 }
@@ -19,10 +19,16 @@
     NSMutableDictionary *paramsDict = [NSMutableDictionary dictionaryWithCapacity:[params count]];
     for (NSString *param in params) {
         NSArray *pairs = [param componentsSeparatedByString:@"="];
-        if ([pairs count] == 2) {
+        if (pairs.count == 2) {
+            // e.g. ?key=value
             NSString *key   = [pairs[0] DPL_stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
             NSString *value = [pairs[1] DPL_stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
             paramsDict[key] = value;
+        }
+        else if (pairs.count == 1) {
+            // e.g. ?key
+            NSString *key = [[pairs firstObject] DPL_stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+            paramsDict[key] = @"";
         }
     }
     return [paramsDict copy];

--- a/Tests/Categories/NSString_DPLQuerySpec.m
+++ b/Tests/Categories/NSString_DPLQuerySpec.m
@@ -44,6 +44,12 @@ describe(@"Dictionary to Query String", ^{
         expect(query).to.equal(@"one=1&two=2");
     });
     
+    it(@"serializes keys with empty value", ^{
+        NSDictionary *params = @{ @"one": @"", @"two": @2 };
+        NSString *query = [NSString DPL_queryStringWithParameters:params];
+        expect(query).to.equal(@"one&two=2");
+    });
+    
     it(@"should percent encode parameters from dictionary into the query string", ^{
         NSDictionary *params = @{ @"one": @"a one", @"two": @"http://www.example.com?foo=bar" };
         NSString *query = [NSString DPL_queryStringWithParameters:params];
@@ -61,11 +67,11 @@ describe(@"Query String to Dictionary", ^{
         expect(params[@"two"]).to.equal(@"2");
     });
     
-    it(@"should ignore incomplete pairs in a query string", ^{
+    it(@"does NOT discard incomplete pairs in a query string", ^{
         NSString *query = @"one=1&two&three=3";
         NSDictionary *params = [query DPL_parametersFromQueryString];
         expect(params[@"one"]).to.equal(@"1");
-        expect(params[@"two"]).to.beNil();
+        expect(params[@"two"]).to.equal(@"");
         expect(params[@"three"]).to.equal(@"3");
     });
     

--- a/Tests/DeepLink/DPLDeepLinkSpec.m
+++ b/Tests/DeepLink/DPLDeepLinkSpec.m
@@ -42,6 +42,13 @@ describe(@"Initialization", ^{
                                  };
         expect(link[@"partner"]).to.equal(@"not-uber");
     });
+    
+    it(@"preserves key only query items", ^{
+        NSURL *url = [NSURL URLWithString:@"seamlessapp://menu?293147"];
+        DPLDeepLink *link = [[DPLDeepLink alloc] initWithURL:url];
+        expect(link.queryParameters[@"293147"]).to.equal(@"");
+        expect(link.URL.absoluteString).to.equal(@"seamlessapp://menu?293147");
+    });
 });
 
 

--- a/Tests/DeepLink/DPLMutableDeepLinkSpec.m
+++ b/Tests/DeepLink/DPLMutableDeepLinkSpec.m
@@ -87,6 +87,12 @@ describe(@"Mutating Deep Links", ^{
         link.path = @"/path/to/there";
         expect(link.URL.absoluteString).to.equal(@"dpl://dpl.com/path/to/there?");
     });
+    
+    it(@"preserves key only query items", ^{
+        DPLMutableDeepLink *link = [[DPLMutableDeepLink alloc] initWithString:@"seamlessapp://menu?293147"];
+        expect(link.queryParameters[@"293147"]).to.equal(@"");
+        expect(link.URL.absoluteString).to.equal(@"seamlessapp://menu?293147");
+    });
 });
 
 


### PR DESCRIPTION
**Depends on #72**

Technically keys missing values in a query string are legit ([rfc3986](http://tools.ietf.org/html/rfc3986#section-3.4)) and we prefer when a url is parsed into a `DPLDeepLink` it is serialized into the same url.

Additionally note that `NSURL` interprets and preserves query data that is not complete key value pairs.

For example:
```objc

NSURL *url = [NSURL URLWithString:@"http://example.com?foo"];
NSLog(@"%@", url.query);

//logs the following
> foo

```

Currently DeepLinkKit will discard `foo` in this situation. This change set preserves the value as a key in `-[DPLDeepLink queryParameters]` with a placeholder value. Upon serialization, the key is placed back in the query of the URL with no value.

e.g. The query parameters of the url `http://example.com?foo&bar=baz` is represented as:
```objc
// deepLink.queryParameters
@{
  @"foo": @"",
  @"bar": @"baz"
}
```
serializing the deep link `deepLink.URL` restores the query to the same state.