### PR TITLE
Correct hosted documentation link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 DeepLink Kit is a splendid route-matching, block-based way to handle your deep links. Rather than decide how to format your URLs, parse them, pass data, and navigate to specific content or perform actions, this library and a few lines of code will get you on your way.
 
-[Full Documentation](http://www.usebutton.com/sdk/deep-links/integration-guide)
+[Full Documentation](https://www.usebutton.com/developers/deep-links/)
 
 ## Check it out
 


### PR DESCRIPTION
The integration guide link returns a 404 - http://www.usebutton.com/sdk/deep-links/integration-guide

This commit updates the link to - https://www.usebutton.com/developers/deep-links/