### PR TITLE
Update documentation comments to silence warnings

### DIFF
--- a/DeepLinkKit/Categories/NSObject+DPLJSONObject.h
+++ b/DeepLinkKit/Categories/NSObject+DPLJSONObject.h
@@ -6,7 +6,6 @@
  Returns a JSON compatible version of the receiver.
  
  @discussion
- 
  - NSDictionary and NSArray will call `DPLJSONObject' on all of their items.
  - Objects in an NSDictionary not keyed by an NSString will be removed.
  - NSNumbers that are NaN or Inf will be represented by a string.

--- a/DeepLinkKit/Protocols/DPLSerializable.h
+++ b/DeepLinkKit/Protocols/DPLSerializable.h
@@ -12,14 +12,14 @@
 
 /**
  Initializes an object with the provided dictionary representation.
- @param An NSDictionary representation of the object to be created.
+ @param dictionary NSDictionary representation of the object to be created.
  */
 - (instancetype)initWithDictionary:(NSDictionary *)dictionary;
 
 
 /**
  Updates the receiver with the provided dictionary representation.
- @param An NSDictionary representation of the object.
+ @param dictionary NSDictionary representation of the object.
  */
 - (void)updateWithRepresentation:(NSDictionary *)dictionary;
 


### PR DESCRIPTION
When DeepLinkKit is installed via CocoaPods with the use_frameworks!
option and the host project has documentation comment checking enabled,
several warnings are emitted. This patch fixes the issues associated
with those warnings.